### PR TITLE
Fixed a small sprite rendering bug.

### DIFF
--- a/lib/quintus_sprites.js
+++ b/lib/quintus_sprites.js
@@ -148,6 +148,7 @@ Quintus.Sprites = function(Q) {
       /* Only worry about context if we have an angle */
       if(p.angle || p.scale) {
         if(!saved) { ctx.save(); }
+        saved = true;
 
         ctx.translate(p.x,p.y);
         ctx.translate(p.cx,p.cy);


### PR DESCRIPTION
If you use scaling or rotation on sprites without opacity the rendering freaks out because the contexts are not restored properly. Adding this line fixed it for me.
