### PR TITLE
Fixed using image for tile 0 in scene

### DIFF
--- a/lib/quintus_2d.js
+++ b/lib/quintus_2d.js
@@ -223,7 +223,7 @@ Quintus["2D"] = function(Q) {
       for(var y=0;y<p.blockTileH;y++) {
         if(tiles[y+blockOffsetY]) {
           for(var x=0;x<p.blockTileW;x++) {
-            if(tiles[y+blockOffsetY][x+blockOffsetX]) {
+            if(tiles[y+blockOffsetY][x+blockOffsetX]!==undefined) {
               sheet.draw(ctx,
                          x*p.tileW,
                          y*p.tileH,


### PR DESCRIPTION
I couldn't use a zero indexed tile image for my scene.
