### PR TITLE
Minor Touch Example Typo

### DIFF
--- a/examples/touch/touch.js
+++ b/examples/touch/touch.js
@@ -155,7 +155,7 @@ window.addEventListener('load',function(e) {
   // sprites on desktop.
   Q.el.addEventListener('mousemove',function(e) {
     var x = e.offsetX || e.layerX,
-        y = e.offsetY || e.layerY
+        y = e.offsetY || e.layerY,
         stage = Q.stage();
 
     // Use the helper methods in Q.touchInput to translate


### PR DESCRIPTION
Just a little bug fix.  The touch example had a list of vars that was missing a comma.
