### PR TITLE
Added directional hits on sprite with no impact movement

### DIFF
--- a/lib/quintus_2d.js
+++ b/lib/quintus_2d.js
@@ -296,11 +296,34 @@ Quintus["2D"] = function(Q) {
         vy: 0,
         ax: 0,
         ay: 0,
+        move: true,
         gravity: 1,
         collisionMask: Q.SPRITE_DEFAULT
       });
       entity.on('step',this,"step");
-      entity.on('hit',this,'collision');
+      this.entity.p.move?entity.on('hit',this,'collision'):entity.on('hit',this,'collide');
+    },
+
+    collide: function(col,last) {
+      var entity = this.entity,
+          p = entity.p;
+        
+      p.x -= 0;
+      p.y -= 0;
+
+      // Top collision
+      if(col.normalY < -0.3) { 
+        entity.trigger("bump.bottom",col);
+      }
+      if(col.normalY > 0.3) {
+        entity.trigger("bump.top",col);
+      }
+      if(col.normalX < -0.3) { 
+        entity.trigger("bump.right",col);
+      }
+      if(col.normalX > 0.3) { 
+        entity.trigger("bump.left",col);
+      }
     },
 
     collision: function(col,last) {


### PR DESCRIPTION
I wanted to have the functionality of 2D directional collision on an sprite but without the Impact/Gravity.

This can be achieved by setting "move:false" inside the extended sprite.
