### PR TITLE
Fix for bug in 2D -> falling through tiles

### DIFF
--- a/lib/quintus_2d.js
+++ b/lib/quintus_2d.js
@@ -180,8 +180,8 @@ Quintus["2D"] = function(Q) {
       var p = this.p,
           tileStartX = Math.floor((obj.p.x - obj.p.cx - p.x) / p.tileW),
           tileStartY = Math.floor((obj.p.y - obj.p.cy - p.y) / p.tileH),
-          tileEndX =  Math.floor((obj.p.x - obj.p.cx + obj.p.w - p.x) / p.tileW),
-          tileEndY =  Math.floor((obj.p.y - obj.p.cy + obj.p.h - p.y) / p.tileH),
+          tileEndX =  Math.ceil((obj.p.x - obj.p.cx + obj.p.w - p.x) / p.tileW),
+          tileEndY =  Math.ceil((obj.p.y - obj.p.cy + obj.p.h - p.y) / p.tileH),
           colObj = this.collisionObject,
           normal = this.collisionNormal,
           col;


### PR DESCRIPTION
Steps to reproduce:

Open demo `platformer` and add following properties to `player`:
- `gravity: 1.9999897453`
- `points: [[-5, -5], [5, -5], [5, 5], [-5, 5]]`

Expected result: Changed properties of the player object

Actual result: Player falls through tiles.
