### PR TITLE
Added an underline feature to UI Text

### DIFF
--- a/lib/quintus_ui.js
+++ b/lib/quintus_ui.js
@@ -207,7 +207,7 @@ Quintus.UI = function(Q) {
     draw: function(ctx) {
        //this.prerender();
       if(this.p.opacity === 0) { return; }
-
+      if(this.p.style == "underline") { this.underline(ctx); }
       if(this.p.oldLabel !== this.p.label) { this.calcSize(); }
 
       this.setFont(ctx);
@@ -242,6 +242,15 @@ Quintus.UI = function(Q) {
                         (this.p.family || "Arial");
 
       return this.fontString;
+    },
+
+    underline: function(ctx){
+        ctx.lineWidth = this.p.size * 0.04;
+        ctx.beginPath();
+        ctx.moveTo( (this.p.w / 2) * -1, this.p.size / 2);
+        ctx.lineTo( this.p.w / 2, this.p.size / 2 );
+        ctx.strokeStyle = this.p.color;
+        ctx.stroke();
     }
 
   });


### PR DESCRIPTION
Underline your titles by adding an underline style to your label.

Usage:

stage.insert(new Q.UI.Text({ 
            label: "Underlined Text",
            style: "underline",
            x: Q.width/2,
            y: Q.height/2
        }));
