### PR TITLE
Underline feature with multi-line support.

### DIFF
--- a/lib/quintus_ui.js
+++ b/lib/quintus_ui.js
@@ -246,11 +246,27 @@ Quintus.UI = function(Q) {
 
     underline: function(ctx){
         ctx.lineWidth = this.p.size * 0.04;
+
+        for(var i = 0; i < this.splitLabel.length; i++){
+        var bottomCoordinates = (-this.p.cy +i * this.p.size * 1.2) + this.p.size * 1.2;
         ctx.beginPath();
-        ctx.moveTo( (this.p.w / 2) * -1, this.p.size / 2);
-        ctx.lineTo( this.p.w / 2, this.p.size / 2 );
+
+        if(this.p.align === 'center') { 
+          ctx.moveTo(-Q.ctx.measureText(this.splitLabel[i]).width/2, bottomCoordinates);
+          ctx.lineTo(Q.ctx.measureText(this.splitLabel[i]).width/2, bottomCoordinates);
+        } else if(this.p.align === 'right') {
+          ctx.moveTo(this.p.cx, bottomCoordinates);
+          ctx.lineTo(-Q.ctx.measureText(this.splitLabel[i]).width + this.p.cx, bottomCoordinates);
+        } else { 
+          ctx.moveTo(-this.p.cx, bottomCoordinates);
+          ctx.lineTo(Q.ctx.measureText(this.splitLabel[i]).width - this.p.cx, bottomCoordinates);
+        }
+
         ctx.strokeStyle = this.p.color;
         ctx.stroke();
+
+      }
+
     }
 
   });


### PR DESCRIPTION
Underline your labels by adding an underline style to your label.

Usage:

stage.insert(new Q.UI.Text({ 
label: "Underlined Text",
style: "underline",
x: Q.width/2,
y: Q.height/2
}));
