### PR TITLE
multilayer support for TMX files

### DIFF
--- a/lib/quintus_2d.js
+++ b/lib/quintus_2d.js
@@ -109,7 +109,8 @@ Quintus["2D"] = function(Q) {
         tileH: 32,
         blockTileW: 10,
         blockTileH: 10,
-        type: 1
+        type: 1,
+        layerIndex: 0
       });
       if(this.p.dataAsset) {
         this.load(this.p.dataAsset);
@@ -143,7 +144,7 @@ Quintus["2D"] = function(Q) {
         var parser = new DOMParser(),
           doc = parser.parseFromString(Q.asset(dataAsset), "application/xml");
 
-        var layer = doc.getElementsByTagName("layer")[0],
+        var layer = doc.getElementsByTagName("layer")[this.p.layerIndex],
             width = parseInt(layer.getAttribute("width")),
             height = parseInt(layer.getAttribute("height"));
 


### PR DESCRIPTION
Added the ability for the user to specify which layer in the TMX file will be used.

Tested in a platformer where I used one layer for the collision and one for background, it works fine:

```
Q.scene("level1",function(stage) {

            //background
            stage.insert(new Q.TileLayer({ dataAsset: 'level1.tmx', layerIndex: 0, sheet: 'tiles', tileW: 70, tileH: 70, type: Q.SPRITE_NONE }));

            stage.collisionLayer(new Q.TileLayer({ dataAsset: 'level1.tmx', layerIndex:1,  sheet: 'tiles', tileW: 70, tileH: 70 }));

            var player = stage.insert(new Q.Player());
            stage.add("viewport").follow(player);          
        });

```
