### PR TITLE
optional bounding box to the viewport to restrict camera to an area

### DIFF
--- a/lib/quintus_2d.js
+++ b/lib/quintus_2d.js
@@ -430,11 +430,23 @@ Quintus["2D"] = function(Q) {
     },
 
     goLeft: function(col) {
-      this.entity.p.vx = -col.impact;
+      this.entity.p.vx = -col.impact;      
+      if(this.entity.p.defaultDirection == 'right') {
+          this.entity.p.flip = 'x';
+      }
+      else {
+          this.entity.p.flip = false;
+      }
     },
 
     goRight: function(col) {
       this.entity.p.vx = col.impact;
+      if(this.entity.p.defaultDirection == 'left') {
+          this.entity.p.flip = 'x';
+      }
+      else {
+          this.entity.p.flip = false;
+      }
     }
   });
 


### PR DESCRIPTION
when adding the viewport to the player, you can new specify a bounding box so that the camera doesn't go outside of this box.

For example if you want to restrict the camera to the level, so that no areas outside the level are shown:

```
Q.scene("level1",function(stage) {

            var background = new Q.TileLayer({ dataAsset: 'level1.tmx', layerIndex: 0, sheet: 'tiles', tileW: 70, tileH: 70, type: Q.SPRITE_NONE });
            stage.insert(background);
            console.log(background);

            stage.collisionLayer(new Q.TileLayer({ dataAsset: 'level1.tmx', layerIndex:1,  sheet: 'tiles', tileW: 70, tileH: 70 }));

            var player = stage.insert(new Q.Player());

            stage.add("viewport").follow(player,{x: true, y: true},{minX: 0, maxX: background.p.w, minY: 0, maxY: background.p.h});

        });

```

See it in action here:    http://static.pablofarias.com/boundingbox/
