### PR TITLE
Update quintus_input.js

### DIFF
--- a/lib/quintus_input.js
+++ b/lib/quintus_input.js
@@ -396,7 +396,7 @@ Quintus.Input = function(Q) {
 
     disableMouseControls: function() {
       if(Q._mouseMove) {
-        Q.el.removeEventListener("mousemove",Q._mouseMove);
+        Q.el.removeEventListener("mousemove",Q._mouseMove, true);
         Q.el.style.cursor = 'inherit';
         Q._mouseMove = null;
       }


### PR DESCRIPTION
addEventListener uses useCapture = true param, and removeEventListener can't remove event if useCapture = false
