### PR TITLE
Added support for specifying cursor

### DIFF
--- a/lib/quintus_input.js
+++ b/lib/quintus_input.js
@@ -383,10 +383,18 @@ Quintus.Input = function(Q) {
       var stageNum = options.stageNum || 0;
       var mouseInputX = options.mouseX || "mouseX";
       var mouseInputY = options.mouseY || "mouseY";
+      var cursor = options.cursor || "off";
 
       var mouseMoveObj = {};
 
-      Q.el.style.cursor = 'none';
+      if(cursor != "on") {
+          if(cursor == "off") {
+              Q.el.style.cursor = 'none';
+          }
+          else {
+              Q.el.style.cursor = cursor;
+          }
+      }
 
       Q.inputs[mouseInputX] = 0;
       Q.inputs[mouseInputY] = 0;


### PR DESCRIPTION
I wanted to be able to specify the cursor styling to use when using `Quintus.input.mouseControls()`. Just added a bit of code to check to see if the user has passed in a `cursor` parameter to `mouseControls()`. If it's not there, it functions as before, and sets the cursor to `none`. If the user just wants a plain old cursor, they can call it with `mouseControls({cursor: 'on'})`. If they want to specify a particular cursor they can likewise pass it in. (Something like: `mouseControls({cursor: 'move'})`.)

Quintus is a lot of fun, by the way! Just starting learning it.
