### PR TITLE
Added end action trigger for joypad

### DIFF
--- a/lib/quintus_input.js
+++ b/lib/quintus_input.js
@@ -360,6 +360,9 @@ Quintus.Input = function(Q) {
                 for(var k=0;k<joypad.triggers.length;k++) {
                   var actionName = joypad.inputs[k];
                   Q.inputs[actionName] = false;
+                    if(joypad.triggers[k]) {
+                        Q.input.trigger(actionName + "Up");
+                    }
                 }
                 joypad.joypadTouch = null;
                 break;


### PR DESCRIPTION
Does not fire the trigger ended action(leftUp, rigtUp etc) at the termination touch with display (touchend)
1. Tap the display to show joypad.
2. Slide your finger left to fire "left" trigger.
3. Slide your finger   up - "up" fires (now actions "left" and "up"). 
4. Slide your finger  only up - trigger "leftUp"  fires (action "left" is end, now only "up").
5. Slide your finger  right - trigger "right"  fires (now action "up" and "right")
6. Tap stop and remove your finger from the display, trigger "upUp" and "rightUp" should fire, but it doesn't
