### PR TITLE
Not capturing unhandled key events

### DIFF
--- a/lib/quintus_input.js
+++ b/lib/quintus_input.js
@@ -115,8 +115,8 @@ Quintus.Input = function(Q) {
           Q.inputs[actionName] = true;
           Q.input.trigger(actionName);
           Q.input.trigger('keydown',e.keyCode);
+          e.preventDefault();
         }
-        e.preventDefault();
       },false);
 
       Q.el.addEventListener("keyup",function(e) {
@@ -125,8 +125,8 @@ Quintus.Input = function(Q) {
           Q.inputs[actionName] = false;
           Q.input.trigger(actionName + "Up");
           Q.input.trigger('keyup',e.keyCode);
+          e.preventDefault();
         }
-        e.preventDefault();
       },false);
 
       Q.el.focus();


### PR DESCRIPTION
This allows the user to still use usual key bindings of browser, ex: ctrl+r to refresh
