### PR TITLE
little improvements from my experience

### DIFF
--- a/lib/quintus_input.js
+++ b/lib/quintus_input.js
@@ -343,6 +343,11 @@ Quintus.Input = function(Q) {
       Q.el.removeEventListener('touchend',this.joypadEnd);
       Q.el.removeEventListener('touchcancel',this.joypadEnd);
       this.touchEnabled = false;
+
+      // clear existing inputs
+      for(var input in Q.inputs) {
+        Q.inputs[input] = false;
+      }
     },
 
     /** 

--- a/lib/quintus_ui.js
+++ b/lib/quintus_ui.js
@@ -286,7 +286,7 @@ Quintus.UI = function(Q) {
     },
 
     highlight: function() {
-      if(!this.sheet() || this.sheet().frames > 1) {
+      if(typeof this.sheet() !== 'undefined' && this.sheet().frames > 1) {
         this.p.frame = 1;
       }
     },


### PR DESCRIPTION
Hi, I've been working with quintus for few months, below you can find few improvements I find useful.
- add actions for Enter and Esc key and few other buttons, "P" for pause i.e.
- on screen touch buttons react on clicks only above them (not whole screen height)
- calling "disableTouchControls" also clean state of inputs (caused bug when I disabled touch controls for menu and enabled again on next level, state from end of previous level was kept, means buttons were pressed on level load)
- allow to extend UI.Button and trigger button click from keyboard (I use it for confirmation buttons, i.e. "play next" you can also click by pressing Enter)

There is some bug in latest Quintus with counting amount of frames, I needed to comment out 85 line in quintus_sprite.js file
`this.frames = this.cols * (Math.ceil(this.h/(this.tileH + this.spacingY)));`, it caused my buttons to display next frame, even that in json for that sprite number of frames is 1
