### PR TITLE
Maximise canvas with a set constraint in setup

### DIFF
--- a/lib/quintus.js
+++ b/lib/quintus.js
@@ -1339,8 +1339,8 @@ var Quintus = function Quintus(opts) {
       document.body.style.padding = 0;
       document.body.style.margin = 0;
 
-      w = Math.min(window.innerWidth,maxWidth);
-      h = Math.min(window.innerHeight - 5,maxHeight);
+      w = options.width || Math.min(window.innerWidth,maxWidth) - ((options.pagescroll)?17:0);
+      h = options.height || Math.min(window.innerHeight - 5,maxHeight);
 
       if(Q.touchDevice) {
         Q.el.style.height = (h*2) + "px";


### PR DESCRIPTION
I wanted a banner type game that could be hosted on a footer of a web page. 
http://ss14-team-61.divshot.io/

```
.setup({ maximize: true })
```

Allowed me to stretch the canvas to the maximum, but I needed a fixed height.
The attached code will give you the ability to set constraints and still have a maximum.

```
.setup({ maximize: true, height: 200 })
```

As your webpage gets longer, the scrollbar appears and sets the alignment of the canvas off.
This will decrease the width of the canvas by 17px.

```
.setup({ maximize: true, height: 200, pagescroll: true })
```
