### PR TITLE
Bugfix #93 — more

### DIFF
--- a/lib/quintus_input.js
+++ b/lib/quintus_input.js
@@ -252,9 +252,11 @@ Quintus.Input = function(Q) {
       opts.size = opts.unit - 2 * opts.gutter;
 
       function getKey(touch) {
-        var pos = Q.input.touchLocation(touch);
+        var pos = Q.input.touchLocation(touch),
+            minY = opts.bottom - opts.unit;
         for(var i=0,len=opts.controls.length;i<len;i++) {
-          if(pos.x < opts.unit * (i+1)) {
+          var minX = opts.left + i * opts.unit + i * opts.gutter;
+          if(pos.x >=  minX && pos.x <= (minX+opts.unit) && pos.y >= minY && pos.y <= (minY+opts.unit)) {
             return opts.controls[i][0];
           }
         }


### PR DESCRIPTION
Buttons were placed correctly, but touch events didn’t take the offset
into account.
Now you can only touch the buttons (may be improved to allow more
reactive space)
