### PR TITLE
Fix for Q.Sprite.center()

### DIFF
--- a/lib/quintus_sprites.js
+++ b/lib/quintus_sprites.js
@@ -584,8 +584,8 @@ Quintus.Sprites = function(Q) {
     */
     center: function() {
       if(this.container) {
-        this.p.x = this.container.p.w / 2;
-        this.p.y = this.container.p.h / 2;
+        this.p.x = 0;
+        this.p.y = 0;
       } else {
         this.p.x = Q.width / 2;
         this.p.y = Q.height / 2;


### PR DESCRIPTION
When centring a sprite inside a container, the x,y coordinates should be set in sprite coordinates (0,0) rather then those of parent (p.w/2,p.h/2).

For a quick test run:

``` js
Q.scene('test',function(stage) {
    var one = stage.insert(new Q.Sprite({x:100, y:100, color:'red',w:200,h:200}));
    var two = stage.insert(new Q.Sprite({color:'blue',w:100,h:100}),one);
    two.center();
});
Q.stageScene('test');
```

As is right now turning two.center(); off will result in the correct behaviour.
