### PR TITLE
Transparent sprite performance improvement

### DIFF
--- a/lib/quintus_sprites.js
+++ b/lib/quintus_sprites.js
@@ -544,7 +544,7 @@ Quintus.Sprites = function(Q) {
     render: function(ctx) {
       var p = this.p;
 
-      if(p.hidden) { return; }
+      if(p.hidden || p.opacity == 0) { return; }
       if(!ctx) { ctx = Q.ctx; }
 
       this.trigger('predraw',ctx);


### PR DESCRIPTION
This skips rendering complete transparent sprites. Bit faster.
