### PR TITLE
Fix Mouse position in canvas with padding

### DIFF
--- a/examples/touch/touch.js
+++ b/examples/touch/touch.js
@@ -154,12 +154,9 @@ window.addEventListener('load',function(e) {
   // in an event listener and use `Stage.locate` to highlight
   // sprites on desktop.
   Q.el.addEventListener('mousemove',function(e) {
-      var el = Q.el, 
-        rect = el.getBoundingClientRect(),
-        style = window.getComputedStyle(el),
-        x = e.clientX - rect.left - parseInt(style.paddingLeft),
-        y = e.clientY - rect.top  - parseInt(style.paddingTop);
-      var stage = Q.stage();
+    var x = e.offsetX || e.layerX,
+        y = e.offsetY || e.layerY,
+        stage = Q.stage();
 
     // Use the helper methods from the Input Module on Q to
     // translate from canvas to stage


### PR DESCRIPTION
The mouse position in an element is measured from the top left corner. When a margin or padding is used this starts outside the drawable area of the canvas. This needs to be taken into account.
