### PR TITLE
Fix Touch position in canvas with padding

### DIFF
--- a/lib/quintus_touch.js
+++ b/lib/quintus_touch.js
@@ -49,20 +49,22 @@ Quintus.Touch = function(Q) {
     },
 
     normalizeTouch: function(touch,stage) {
-			var el = Q.el, 
-				rect = el.getBoundingClientRect()
-				posX = touch.clientX - rect.left,
-				posY = touch.clientY - rect.top;
-		
-			if(Q._isUndefined(posX) || Q._isUndefined(posY)) {
-				posX = touch.offsetX;
-				posY = touch.offsetY;
-			}	  
-		
-			if(Q._isUndefined(posX) || Q._isUndefined(posY)) {
-				posX = touch.layerX;
-				posY = touch.layerY;
-			}
+
+    var el = Q.el, 
+      rect = el.getBoundingClientRect(),
+      style = window.getComputedStyle(el),
+      posX = touch.clientX - rect.left - parseInt(style.paddingLeft),
+      posY = touch.clientY - rect.top  - parseInt(style.paddingTop);
+
+      if(Q._isUndefined(posX) || Q._isUndefined(posY)) {
+         posX = touch.offsetX;
+         posY = touch.offsetY;
+      }   
+
+      if(Q._isUndefined(posX) || Q._isUndefined(posY)) {
+        posX = touch.layerX;
+        posY = touch.layerY;
+      }
 
       if(Q._isUndefined(posX) || Q._isUndefined(posY)) {
         if(Q.touch.offsetX === void 0) {
@@ -78,8 +80,8 @@ Quintus.Touch = function(Q) {
         posY = touch.pageY - Q.touch.offsetY;
       }
 
-      this.touchPos.p.ox = this.touchPos.p.px = (posX)/ Q.cssWidth * Q.width;
-      this.touchPos.p.oy = this.touchPos.p.py = (posY) / Q.cssHeight * Q.height;
+      this.touchPos.p.ox = this.touchPos.p.px = posX / Q.cssWidth * Q.width;
+      this.touchPos.p.oy = this.touchPos.p.py = posY / Q.cssHeight * Q.height;
       
       if(stage.viewport) {
         this.touchPos.p.px /= stage.viewport.scale;
@@ -94,7 +96,6 @@ Quintus.Touch = function(Q) {
       this.touchPos.obj = null;
       return this.touchPos;
     },
-
 
     touch: function(e) {
       var touches = e.changedTouches || [ e ];


### PR DESCRIPTION
The mouse position in an element is measured from the top left corner. When a margin or padding is used this starts outside the drawable area of the canvas. This needs to be taken into account.
