### PR TITLE
Fix for UI.Text align

### DIFF
--- a/lib/quintus_ui.js
+++ b/lib/quintus_ui.js
@@ -375,7 +375,7 @@ Quintus.UI = function(Q) {
      @for Q.UI.Text
     */
     asset: function() {
-       return this.el;
+      return this.el;
     },
 
     /**


### PR DESCRIPTION
align is used to both set the alignment in the front string and to physically move the location where the font string is to be. The end result is that align is always centered.

This fixes this by making the default alignment centred and removing the physical positioning of the text.Bounding points are adjusted accordingly.
