### PR TITLE
Added a volume control

### DIFF
--- a/lib/quintus_audio.js
+++ b/lib/quintus_audio.js
@@ -104,6 +104,9 @@ Quintus.Audio = function(Q) {
       Q.audio.channels[i] = {};
       Q.audio.channels[i]['channel'] = new Audio(); 
       Q.audio.channels[i]['finished'] = -1;	
+      if(Q.audio.volume < 1) {
+        Q.audio.channels[i]['channel']['volume'] = Q.audio.volume;
+      }
     }
 
     // Play a single sound, optionally debounced 

--- a/lib/quintus_audio.js
+++ b/lib/quintus_audio.js
@@ -6,7 +6,8 @@ Quintus.Audio = function(Q) {
     channels: [],
     channelMax:  Q.options.channelMax || 10,
     active: {},
-    play: function() {}
+    play: function() {},
+    volume: 1
   };
 
 
@@ -60,10 +61,16 @@ Quintus.Audio = function(Q) {
       }
 
       var soundID = Q.audio.soundID++;
-
+    
       var source = Q.audioContext.createBufferSource();
+      var gainNode = Q.audioContext.createGain();
+      
       source.buffer = Q.asset(s);
-      source.connect(Q.audioContext.destination);
+      source.connect(gainNode);
+      
+      gainNode.connect(Q.audioContext.destination);
+      gainNode.gain.value = Q.audio.volume;
+           
       if(options && options['loop']) {
         source.loop = true;
       } else {


### PR DESCRIPTION
The Audio object now has a volume property that can be set. This uses a
GainNode which connects the sound asset to the destination. I think it
makes sense to have this control on the same settings level as channels.
This doesn't work with IE11 since it still doesn't support the Web Audio
API.

The range is from 0 to 1, with the default 1 so it doesn't conflict with the current release.
