### PR TITLE
Allow Meta key to be used for cmd+r shortcut on Mac

### DIFF
--- a/lib/quintus_input.js
+++ b/lib/quintus_input.js
@@ -177,8 +177,8 @@ Quintus.Input = function(Q) {
           Q.input.trigger(actionName);
           Q.input.trigger('keydown',e.keyCode);
         }
-        if(!e.ctrlKey) {
-            e.preventDefault();
+        if(!e.ctrlKey && !e.metaKey) {
+          e.preventDefault();
         }
       },false);
 


### PR DESCRIPTION
Same as this commit: https://github.com/cykod/Quintus/commit/15e9c25d92b9afb7233a5b4735d0e6cdeb3583fe

But on Mac OSX we use cmd+r for refreshing, not ctrl+r
