### PR TITLE
viewport.follow(): Viewport now centers on sprite

### DIFF
--- a/lib/quintus_2d.js
+++ b/lib/quintus_2d.js
@@ -50,10 +50,10 @@ Quintus["2D"] = function(Q) {
 
       this[first === true ? 'centerOn' : 'softCenterOn'](
                     followX ?
-                      this.following.p.x + this.following.p.w/2 - this.offsetX :
+                      this.following.p.x - this.offsetX :
                       undefined,
                     followY ?
-                     this.following.p.y + this.following.p.h/2 - this.offsetY :
+                     this.following.p.y - this.offsetY :
                      undefined
                   );
     },


### PR DESCRIPTION
p.x and p.x properties are the center of the sprite, no need to add p.w and p.h anymore.
