### PR TITLE
Adding a "bump" event

### DIFF
--- a/lib/quintus_2d.js
+++ b/lib/quintus_2d.js
@@ -465,24 +465,28 @@ Quintus["2D"] = function(Q) {
         if(!p.skipCollide && p.vy > 0) { p.vy = 0; }
         col.impact = impactY;
         entity.trigger("bump.bottom",col);
+        entity.trigger("bump",col);
       }
       if(col.normalY > 0.3) {
         if(!p.skipCollide && p.vy < 0) { p.vy = 0; }
         col.impact = impactY;
 
         entity.trigger("bump.top",col);
+        entity.trigger("bump",col);
       }
 
       if(col.normalX < -0.3) {
         if(!p.skipCollide && p.vx > 0) { p.vx = 0;  }
         col.impact = impactX;
         entity.trigger("bump.right",col);
+        entity.trigger("bump",col);
       }
       if(col.normalX > 0.3) {
         if(!p.skipCollide && p.vx < 0) { p.vx = 0; }
         col.impact = impactX;
 
         entity.trigger("bump.left",col);
+        entity.trigger("bump",col);
       }
     },
 


### PR DESCRIPTION
Adding `obj.on("bump",f)` as a shorthand for `obj.on("bump.top, bump.bottom, bump.left, bump.right",f)`.

I'm not sure if it _should_ be merged, but seems like a nice-to-have feature :)