### PR TITLE
Mouse wheel support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ docs/
 doc/
 bin/
 s3.json
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs/
 doc/
 bin/
 s3.json
+.idea/

--- a/lib/quintus_input.js
+++ b/lib/quintus_input.js
@@ -605,9 +605,25 @@ Quintus.Input = function(Q) {
         }
       };
 
+      /**
+       * Fired when the user scrolls the mouse wheel up or down
+       * Anyone subscribing to the "mouseWheel" event will receive an event with one numeric parameter
+       * indicating the scroll direction. -1 for down, 1 for up.
+       * @private
+       */
+      Q._mouseWheel = function(e) {
+        // http://www.sitepoint.com/html5-javascript-mouse-wheel/
+        // cross-browser wheel delta
+        e = window.event || e; // old IE support
+        var delta = Math.max(-1, Math.min(1, (e.wheelDelta || -e.detail)));
+        Q.input.trigger('mouseWheel', delta);
+      };
+
       Q.el.addEventListener('mousemove',Q._mouseMove,true);
       Q.el.addEventListener('touchstart',Q._mouseMove,true);
       Q.el.addEventListener('touchmove',Q._mouseMove,true);
+      Q.el.addEventListener('mousewheel',Q._mouseWheel,true);
+      Q.el.addEventListener('DOMMouseScroll',Q._mouseWheel,true);
     },
 
     /**
@@ -619,6 +635,8 @@ Quintus.Input = function(Q) {
     disableMouseControls: function() {
       if(Q._mouseMove) {
         Q.el.removeEventListener("mousemove",Q._mouseMove, true);
+        Q.el.removeEventListener("mousewheel",Q._mouseWheel, true);
+        Q.el.removeEventListener("DOMMouseScroll",Q._mouseWheel, true);
         Q.el.style.cursor = 'inherit';
         Q._mouseMove = null;
       }


### PR DESCRIPTION
Added mousewheel support. To detect a mousewheel event, ensure that Quintus mouseControls are enabled and bind to the "mouseWheel" event.
```javascript
Q.input.on("mouseWheel", yourObject, "yourEventHandlerName");
```

Tested mousewheel functionality in Chrome 40, Firefox 37, and IE11.