### PR TITLE
quintus-touch: fixed Error caused by assign to readonly property on iOS

### DIFF
--- a/lib/quintus_touch.js
+++ b/lib/quintus_touch.js
@@ -109,7 +109,7 @@ Quintus.Touch = function(Q) {
 
           if(!stage) { continue; }
 
-          touch.identifier = touch.identifier || 0;
+          var touchIdentifier = touch.identifier || 0;
           var pos = this.normalizeTouch(touch,stage);
 
           stage.regrid(pos,true);
@@ -122,19 +122,19 @@ Quintus.Touch = function(Q) {
           }
 
           if(obj && !this.touchedObjects[obj]) {
-            this.activeTouches[touch.identifier] = {
+            this.activeTouches[touchIdentifier] = {
               x: pos.p.px,
               y: pos.p.py,
               origX: obj.p.x,
               origY: obj.p.y,
               sx: pos.p.ox,
               sy: pos.p.oy,
-              identifier: touch.identifier,
+              identifier: touchIdentifier,
               obj: obj,
               stage: stage
             };
             this.touchedObjects[obj.p.id] = true;
-            obj.trigger('touch', this.activeTouches[touch.identifier]);
+            obj.trigger('touch', this.activeTouches[touchIdentifier]);
             break;
           }
 
@@ -148,10 +148,10 @@ Quintus.Touch = function(Q) {
       var touches = e.changedTouches || [ e ];
 
       for(var i=0;i<touches.length;i++) {
-        var touch = touches[i];
-        touch.identifier = touch.identifier || 0;
+        var touch = touches[i],
+            touchIdentifier = touch.identifier || 0;
 
-        var active = this.activeTouches[touch.identifier],
+        var active = this.activeTouches[touchIdentifier],
             stage = active && active.stage;
 
         if(active) {
@@ -171,16 +171,15 @@ Quintus.Touch = function(Q) {
       var touches = e.changedTouches || [ e ];
 
       for(var i=0;i<touches.length;i++) {
-        var touch = touches[i];
+        var touch = touches[i],
+            touchIdentifier = touch.identifier || 0;
 
-        touch.identifier = touch.identifier || 0;
-
-        var active = this.activeTouches[touch.identifier];
+        var active = this.activeTouches[touchIdentifier];
 
         if(active) {
           active.obj.trigger('touchEnd', active);
           delete this.touchedObjects[active.obj.p.id];
-          this.activeTouches[touch.identifier] = null;
+          this.activeTouches[touchIdentifier] = null;
         }
       }
       e.preventDefault();


### PR DESCRIPTION
Error occured on iOS8 Safari where a readonly properties cannot be assigned with a new value without throwing an uncaught error