### PR TITLE
fixed: horizontal repeating texture suddenly ending in view

### DIFF
--- a/lib/quintus_anim.js
+++ b/lib/quintus_anim.js
@@ -120,7 +120,7 @@ Quintus.Anim = function(Q) {
           viewY = Math.floor(this.stage.viewport ? this.stage.viewport.y : 0),
           offsetX = Math.floor(p.x + viewX * this.p.speedX),
           offsetY = Math.floor(p.y + viewY * this.p.speedY),
-          curX, curY, startX;
+          curX, curY, startX, endX, endY;
       if(p.repeatX) {
         curX = -offsetX % p.repeatW;
         if(curX > 0) { curX -= p.repeatW; }
@@ -135,9 +135,11 @@ Quintus.Anim = function(Q) {
       }
 
       startX = curX;
-      while(curY < Q.height / scale) {
+      endX = Q.width / scale + p.repeatW;
+      endY = Q.height / scale + p.repeatH;
+      while(curY < endY) {
         curX = startX;
-        while(curX < Q.width / scale) {
+        while(curX < endX) {
           if(sheet) {
             sheet.draw(ctx,curX + viewX,curY + viewY,p.frame);
           } else {


### PR DESCRIPTION
I had the problem, that a repeating background texture suddenly ends within the viewport at a certain scaling of the viewport. Fixed it by increasing the range of texture repetition by the `p.repeatH` as well as `p.repeatW`