### PR TITLE
fix (sprites) : gap with spaced tilset

### DIFF
--- a/lib/quintus_sprites.js
+++ b/lib/quintus_sprites.js
@@ -85,7 +85,7 @@ Quintus.Sprites = function(Q) {
       }
 
       this.cols = this.cols ||
-                  Math.floor(this.w / (this.tileW + this.spacingX));
+                  Math.floor((this.w + this.spacingX) / (this.tileW + this.spacingX));
 
       this.frames = this.cols * (Math.floor(this.h/(this.tileH + this.spacingY)));
     },


### PR DESCRIPTION
Fix gap when spaced tilset have no spacing after last line tile

With gap : 
1 2 3
4 5 6

Without gap : 
1 2 3 4
5 6 7 8

tile four is not on new line if he haven't needed spacing on his right