### PR TITLE
Fixes bug resulting in sprite sheet playback at 2x speed.

### DIFF
--- a/lib/quintus_anim.js
+++ b/lib/quintus_anim.js
@@ -40,7 +40,6 @@ Quintus.Anim = function(Q) {
         if(p.animationChanged) {
           p.animationChanged = false;
         } else {
-          p.animationTime += dt;
           if(p.animationTime > rate) {
             stepped = Math.floor(p.animationTime / rate);
             p.animationTime -= stepped * rate;

--- a/lib/quintus_anim.js
+++ b/lib/quintus_anim.js
@@ -134,8 +134,9 @@ Quintus.Anim = function(Q) {
       }
 
       startX = curX;
-      endX = Q.width / scale + p.repeatW;
-      endY = Q.height / scale + p.repeatH;
+      endX = Q.width / Math.abs(scale) / Math.abs(p.scale || 1) + p.repeatW;
+      endY = Q.height / Math.abs(scale) / Math.abs(p.scale || 1) + p.repeatH;
+
       while(curY < endY) {
         curX = startX;
         while(curX < endX) {


### PR DESCRIPTION
Double incrementation of the animationTime property in the Quintus.Anim module was causing sprite sheets to playback at double the intended rate.