### PR TITLE
quintusCore fixed to not override 'window' when using module.exports

### DIFF
--- a/lib/quintus.js
+++ b/lib/quintus.js
@@ -28,7 +28,7 @@ various other modules:
 @module Quintus
 */
 
-var quintusCore = function(window,key) { 
+var quintusCore = function(exportTarget,key) { 
   "use strict";
 
 /**
@@ -52,7 +52,7 @@ var quintusCore = function(window,key) {
 
 @class Quintus
 **/
-var Quintus = window[key] = function(opts) {
+var Quintus = exportTarget[key] = function(opts) {
 
   /**
    A la jQuery - the returned `Q` object is actually
@@ -2249,6 +2249,10 @@ var Quintus = window[key] = function(opts) {
 // Lastly, add in the `requestAnimationFrame` shim, if necessary. Does nothing
 // if `requestAnimationFrame` is already on the `window` object.
 (function() {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
     var lastTime = 0;
     var vendors = ['ms', 'moz', 'webkit', 'o'];
     for(var x = 0; x < vendors.length && !window.requestAnimationFrame; ++x) {


### PR DESCRIPTION
While I'm sure it was well intended, using `window` as the name of the export target argument in the `quintusCore` function turns out to be a problem when using front end bundlers like Browserify or Webpack. The existence of `module.exports` does not negate the possibility that `window` will also exist (later, during browser runtime).

My change simply gets rid of the `window` function argument and replaces it with `exportTarget`. The only place `exportTarget` actually gets used is when `var Quintus` gets attached. All other references to `window` in this file invariably refer to the actual browser `window` global, which is no longer overridden, so we can leave those be.

The only problem now is that we run a shim for `setAnimationFrame` which might try to act on a `window` object that might not exist. It's fundamentally silly anyway to try to add this when we're on the server side, so I just made that shim exit early if `window`'s type is `'undefined'`.