### PR TITLE
Extendable components / sprites without points don't break update

### DIFF
--- a/lib/quintus.js
+++ b/lib/quintus.js
@@ -1752,11 +1752,13 @@ var Quintus = exportTarget[key] = function(opts) {
         fileExt = fileParts[fileParts.length-1].toLowerCase();
 
     if(document.location.origin === "file://" || document.location.origin === "null") {
-      if(!Q.fileURLAlert) {
-        Q.fileURLAlert = true;
-        alert("Quintus Error: Loading assets is not supported from file:// urls - please run from a local web-server and try again");
+      if (!(window && window.process && window.process.type)) { // otherwise we're probably using electron so it's OK
+        if(!Q.fileURLAlert) {
+          Q.fileURLAlert = true;
+          alert("Quintus Error: Loading assets is not supported from file:// urls - please run from a local web-server and try again");
+        }
+        return errorCallback();
       }
-      return errorCallback();
     }
 
     request.onreadystatechange = function() {

--- a/lib/quintus.js
+++ b/lib/quintus.js
@@ -1157,7 +1157,7 @@ var Quintus = exportTarget[key] = function(opts) {
     methods.componentName = "." + name;
     var Comp;
     if(base) {
-      Comp = typeof base === 'string' ? Q.components[base] : base;
+      Comp = Q._isString(base) ? Q.components[base] : base;
     } else {
       Comp = Q.Component;
     }

--- a/lib/quintus.js
+++ b/lib/quintus.js
@@ -1148,13 +1148,15 @@ var Quintus = exportTarget[key] = function(opts) {
    @for Quintus
    @method Q.component
    @param {String} name - component name
-   @param {Object} metehods - hash of methods for the component
+   @param {Object} methods - hash of methods for the component
+   @param {Component} base - base Component to extend
   */
-  Q.component = function(name,methods) {
+  Q.component = function(name,methods,base) {
     if(!methods) { return Q.components[name]; }
     methods.name = name;
     methods.componentName = "." + name;
-    return (Q.components[name] = Q.Component.extend(name + "Component",methods));
+    var Comp = base || Q.Component;
+    return (Q.components[name] = Comp.extend(name + "Component",methods));
   };
 
 

--- a/lib/quintus.js
+++ b/lib/quintus.js
@@ -1148,14 +1148,19 @@ var Quintus = exportTarget[key] = function(opts) {
    @for Quintus
    @method Q.component
    @param {String} name - component name
-   @param {Object} methods - hash of methods for the component
-   @param {Component} base - base Component to extend
+   @param {Object} [methods] - hash of methods for the component
+   @param {Component || string} [base] - base Component to extend
   */
   Q.component = function(name,methods,base) {
     if(!methods) { return Q.components[name]; }
     methods.name = name;
     methods.componentName = "." + name;
-    var Comp = base || Q.Component;
+    var Comp;
+    if(base) {
+      Comp = typeof base === 'string' ? Q.components[base] : base;
+    } else {
+      Comp = Q.Component;
+    }
     return (Q.components[name] = Comp.extend(name + "Component",methods));
   };
 

--- a/lib/quintus_audio.js
+++ b/lib/quintus_audio.js
@@ -69,6 +69,8 @@ Quintus.Audio = function(Q) {
       source.connect(Q.audioContext.destination);
       if(options && options['loop']) {
         source.loop = true;
+        source.loopStart = options['loopStart'] || 0;
+        source.loopEnd = options['loopEnd'] || 0;
       } else {
         setTimeout(function() {
           Q.audio.removeSound(soundID);

--- a/lib/quintus_sprites.js
+++ b/lib/quintus_sprites.js
@@ -678,7 +678,9 @@ Quintus.Sprites = function(Q) {
       this.trigger('prestep',dt);
       if(this.step) { this.step(dt); }
       this.trigger('step',dt);
-      Q._generateCollisionPoints(this);
+      if(this.p.points) {
+        Q._generateCollisionPoints(this);
+      }
 
       // Ugly coupling to stage - workaround?
       if(this.stage && this.children.length > 0) {


### PR DESCRIPTION
I apologize for including two separate features in one pull request - they ended up that way. I can separate the commits if needed, but they're each fairly small.
1. Not all sprites necessarily have points or need them, but the engine breaks if Sprites don't have provided points, when it tries to create collision points. I just updated the code so that no collision points are generated if no points exist (this problem will never come up anyway if you're using the 2d module). The change makes simple sprite animations without need for collision detection easy and lightweight.
2. I made it possible to extend components. They are, after all, classes just like any other, except that they don't have a neat interface for being extended themselves (since they've clearly been intended to just be attached to other objects). The use case that inspired me to code in this feature is wanting to override some elements of platformerControls, without having to duplicate the entire class.

I adapted the existing component creation method to accommodate extension. Pass in the parent as the third argument. You can use the following to create a component called 'endlessRunnerControls' that inherits from 'platformerControls' but overrides the step function:

```
Q.component('endlessRunnerControls', {
  step: function (dt) {
    ...
  }
}, 'platformerControls');
```
