### PR TITLE
inject 'tile' elements into 'data' if 'data' is csv-encoded

### DIFF
--- a/lib/quintus_tmx.js
+++ b/lib/quintus_tmx.js
@@ -164,6 +164,22 @@ Quintus.TMX = function(Q) {
  };
 
  Q._tmxProcessTileLayer = function(stage,gidMap,tileProperties,layer) {
+
+	// https://github.com/cykod/Quintus/issues/179
+	// inject <tile> elements into <data> if <data> is csv-encoded --->
+	var dataTag = layer.querySelectorAll("data")[0];
+	if (attr(dataTag, 'encoding') === 'csv'){
+		var gids = dataTag.textContent.replace(/[^0-9,]/g,'').split(',');
+		dataTag.textContent = '';
+		var tile = document.createElement('tile');
+		for (var i = 0, qty = gids.length; i < qty; i++){
+			var t = tile.cloneNode();
+			t.setAttribute('gid', gids[i]);
+			dataTag.appendChild(t);
+		}
+	}
+	// <---
+	
    var tiles = layer.querySelectorAll("tile"),
        width = attr(layer,'width'),
        height = attr(layer,'height');


### PR DESCRIPTION
Quick dirty fix: CSV support for TMX layers. Fixes #179
